### PR TITLE
Update SLES-51061_CFCB0D20.pnach

### DIFF
--- a/patches/SLES-51061_CFCB0D20.pnach
+++ b/patches/SLES-51061_CFCB0D20.pnach
@@ -1,3 +1,21 @@
+//------------------------------------------------
+// ---- Notes by TKBS: ----
+// * Add Original Values 
+// * Add Original & New Instructions 
+// * Attempt to Port to 2002/2003 Hybrid Version: https://www.moddb.com/mods/gta-vice-city-mods
+// Current WiP == Cheat Table == 
+// Current WiP == Pnach  == https://github.com/SomeGTAVCCodes/GTA-Vice-City-PS2/blob/main/pnach/pcsx2%201.6/cheats/CFCB0D20%20-%20GTA%20Vice%20City%20%5BPAL%5D%20(2003).pnach
+
+i fucking hate github so thought i try this dumb fork shit and the wrose file management system ever.
+
+Absioultely no way ill be able to port hafl the instructions address or values but whatever lets go1!
+//------------------------------------------------
+
+
+//------------------------------------------------
+// ---- [Widescreen 16:9] by Peter Delta: ----
+// * https://github.com/PeterDelta/PCSX2
+//------------------------------------------------
 gametitle=Grand Theft Auto - Vice City (PAL-M) (v2.03) SLES-51061 CFCB0D20
 
 [Widescreen 16:9]


### PR DESCRIPTION
The following is information that may help create Widescreen for Pal 2002 Beta && Hybrid Versions:
**CRC = 09AAE688** || BMB: Beta/ Marketting Build
**CRC = 31A67C86** || Hybrid (Modified & Updated BMB) 
* I added the "Super Widescreen" value i found.

Here is my widescreen stuff if you can do something with it:
https://github.com/SomeGTAVCCodes/GTA-Vice-City-PS2/tree/main/GTA_VC_Cheats/Widescreen

image of Super Widescreen, but with upside down issue:
https://github.com/SomeGTAVCCodes/GTA-Vice-City-PS2/blob/main/GTA_VC_Cheats/Widescreen/imgs/widescreen%20test.png

History:
* I started with the NTSC 20+ year old Code, which is not great. 
* Ported it to PAL 2003, that was fine, but might not have been perfect.
* Then failed to port it to the 2002 Beta & Hybrid Versions.

That is when i discovered the Super wide & upside down effect.
Failed at porting a few instructions, especially ones that jump over or to another address.

Then i discoverd  Peter D's Patches for PAL - 

Make PAL great again! 

